### PR TITLE
Factory versus Constructor Function

### DIFF
--- a/tests/unit/parser.ts
+++ b/tests/unit/parser.ts
@@ -16,7 +16,6 @@ import parse, {
 
 registerSuite(function () {
 	let doc: Document;
-	let handle: RegistrationHandle<any>;
 
 	class Foo implements ParserObject {
 		constructor(node: HTMLElement, options?: any) {
@@ -68,14 +67,14 @@ registerSuite(function () {
 					doc: doc
 				});
 
-				const foo = new handle.Ctor();
+				const foo = handle.factory();
 				assert(foo.node, 'There is something assigned to foo.node');
 				assert.strictEqual(foo.node.tagName.toLowerCase(), 'my-foo',
 					'Constructor creates a node with the right tagName');
-				assert.strictEqual(handle.Ctor.prototype, proto,
+				assert.strictEqual(handle.factory.prototype, proto,
 					'The passed prototype is the constructors prototype');
 
-				const foo1 = new handle.Ctor(<HTMLElement> null, {
+				const foo1 = handle.factory(<HTMLElement> null, {
 					foo: 'bar'
 				});
 				assert.strictEqual(foo1.foo, 'bar', 'Options are mixed in properly');
@@ -87,8 +86,8 @@ registerSuite(function () {
 					doc: doc
 				});
 
-				assert.strictEqual(handle.Ctor, Foo,
-					'The passed constructor should equal the handles constructor');
+				const instance = handle.factory();
+				assert.instanceOf(instance, Foo, 'instance is an instance of Foo');
 				handle.destroy();
 			},
 			'Ctor': function () {
@@ -97,11 +96,13 @@ registerSuite(function () {
 				}
 
 				interface FooConstructor {
-					new (object?: any): FooType;
+					new (node?: HTMLElement, object?: any): FooType;
 					prototype: FooType;
 				}
 
-				function Foo(object?: any) {}
+				function Foo(node?: HTMLElement, object?: any): FooType {
+					return;
+				}
 
 				Foo.prototype = {
 					id: undefined,
@@ -114,9 +115,12 @@ registerSuite(function () {
 					Ctor: <FooConstructor> <any> Foo,
 					doc: doc
 				});
-				assert.strictEqual(handle.Ctor, Foo,
-					'The passed constructor should equal the handles constructor');
+				const instance = handle.factory();
+				assert.instanceOf(instance, Foo, 'instance is an instance of Foo');
 				handle.destroy();
+			},
+			'factory': function () {
+				//
 			},
 			'map': function () {
 				const proto = {
@@ -125,14 +129,34 @@ registerSuite(function () {
 					baz: true
 				};
 
+				interface QatType extends ParserObject {
+					node: HTMLElement;
+					id: string;
+					qat: boolean;
+				}
+
+				const factory = function factory(node: HTMLElement, options?: any): QatType {
+					return Object.create({
+						node: undefined,
+						id: undefined,
+						qat: true
+					});
+				};
+
 				const handle = register({
 					'my-foo': { Ctor: Foo, doc: doc },
 					'my-bar': { Ctor: Bar, doc: doc },
-					'my-baz': { proto: proto, doc: doc }
+					'my-baz': { proto: proto, doc: doc },
+					'my-qat': { factory: factory, doc: doc }
 				});
-				assert.strictEqual(handle.Ctors['my-foo'], Foo, 'Constructor should match');
-				assert.strictEqual(handle.Ctors['my-bar'], Bar, 'Constructor should match');
-				assert.strictEqual(handle.Ctors['my-baz'].prototype, proto, 'Prototype should match');
+				const foo: Foo = handle.factories['my-foo'](null);
+				const bar: Bar = handle.factories['my-bar'](null);
+				const baz: typeof proto = handle.factories['my-baz'](null);
+				const qat: QatType = handle.factories['my-qat'](null);
+				assert.instanceOf(foo, Foo, 'foo is instance of Foo');
+				assert.instanceOf(bar, Bar, 'bar is instance of Bar');
+				assert.isTrue(baz.baz, 'baz.baz is true');
+				assert.isTrue(qat.qat, 'qat.qat is true');
 				handle.destroy();
 			},
 			'throws': function () {
@@ -447,7 +471,7 @@ registerSuite(function () {
 			'callback': function () {
 				const dfd = this.async(500);
 				let watchHandle: Handle;
-				let handle: RegistrationHandle<any>;
+				let handle: RegistrationHandle<any, any>;
 				let callbackCount = 0;
 
 				const foo6 = doc.createElement('my-foo');

--- a/tests/unit/parser.ts
+++ b/tests/unit/parser.ts
@@ -120,7 +120,24 @@ registerSuite(function () {
 				handle.destroy();
 			},
 			'factory': function () {
-				//
+				const proto = {
+					id: <string> undefined,
+					node: <HTMLElement> undefined,
+					foo: 'foo'
+				};
+
+				const factory = function factory(node: HTMLElement, options?: any): typeof proto {
+					return Object.create(proto);
+				};
+
+				const handle = register('my-foo', {
+					factory: factory,
+					doc: doc
+				});
+				const instance = handle.factory();
+				assert.strictEqual(factory, handle.factory, 'factory should be passed through');
+				assert.strictEqual(instance.foo, 'foo', 'created with right prototype');
+				handle.destroy();
 			},
 			'map': function () {
 				const proto = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,40 +1,40 @@
 {
-    "version": "1.6.2",
-    "compilerOptions": {
-        "declaration": false,
-        "module": "umd",
-        "noImplicitAny": true,
-        "outDir": "_build/",
-        "removeComments": false,
-        "sourceMap": true,
-        "target": "es5"
-    },
-    "filesGlob": [
-        "./typings/tsd.d.ts",
-        "./src/**/*.ts",
-        "./tests/**/*.ts",
-        "./_modules/**/*.d.ts"
-    ],
-    "files": [
-        "./typings/tsd.d.ts",
-        "./src/has.ts",
-        "./src/parser.ts",
-        "./src/watch.ts",
-        "./tests/functional/all.ts",
-        "./tests/intern-local.ts",
-        "./tests/intern.ts",
-        "./tests/support/jsdom.ts",
-        "./tests/typings/chai/chai.d.ts",
-        "./tests/typings/digdug/digdug.d.ts",
-        "./tests/typings/dojo2/dojo.d.ts",
-        "./tests/typings/intern/intern.d.ts",
-        "./tests/typings/jsdom/jsdom.d.ts",
-        "./tests/typings/leadfoot/leadfoot.d.ts",
-        "./tests/typings/parser/parser.d.ts",
-        "./tests/typings/tsd.d.ts",
-        "./tests/unit/all.ts",
-        "./tests/unit/parser.ts",
-        "./tests/unit/watch.ts",
-        "./_modules/dojo-core/_typings/dojo-core/dojo-core-2.0.0-pre.d.ts"
-    ]
+	"version": "1.6.2",
+	"compilerOptions": {
+		"declaration": false,
+		"module": "umd",
+		"noImplicitAny": true,
+		"outDir": "_build/",
+		"removeComments": false,
+		"sourceMap": true,
+		"target": "es5"
+	},
+	"filesGlob": [
+		"./typings/tsd.d.ts",
+		"./src/**/*.ts",
+		"./tests/**/*.ts",
+		"./_modules/**/*.d.ts"
+	],
+	"files": [
+		"./typings/tsd.d.ts",
+		"./src/has.ts",
+		"./src/parser.ts",
+		"./src/watch.ts",
+		"./tests/functional/all.ts",
+		"./tests/intern-local.ts",
+		"./tests/intern.ts",
+		"./tests/support/jsdom.ts",
+		"./tests/typings/chai/chai.d.ts",
+		"./tests/typings/digdug/digdug.d.ts",
+		"./tests/typings/dojo2/dojo.d.ts",
+		"./tests/typings/intern/intern.d.ts",
+		"./tests/typings/jsdom/jsdom.d.ts",
+		"./tests/typings/leadfoot/leadfoot.d.ts",
+		"./tests/typings/parser/parser.d.ts",
+		"./tests/typings/tsd.d.ts",
+		"./tests/unit/all.ts",
+		"./tests/unit/parser.ts",
+		"./tests/unit/watch.ts",
+		"./_modules/dojo-core/_typings/dojo-core/dojo-core-2.0.0-pre.d.ts"
+	]
 }


### PR DESCRIPTION
Related to dojo/compose#6, this branch refactors so that the dojo/parser utilises factory functions.  In addition it will generate factory functions for constructors or prototypes.