### PR TITLE
Add multiple-document support.

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -6,7 +6,11 @@ import Registry from 'dojo-core/Registry';
 import { queueMicroTask } from 'dojo-core/queue';
 import domWatch, { WatcherRecord, ChangeType } from './watch';
 
-export interface IdMap {
+function isDocument(value: any): value is Document {
+	return value instanceof Document;
+}
+
+interface IdMap {
 	[id: string]: ParserObject;
 }
 
@@ -128,13 +132,15 @@ export function byNode<T extends ParserObject>(node: HTMLElement): T {
 
 /**
  * The public API for retrieving a parser object by ID
- * @param  {string}                 id The ID of the parser object to retrieve
  * @param  {Document}               doc The optional Document. Defaults to `document`.
+ * @param  {string}                 id The ID of the parser object to retrieve
  * @return {T extends ParserObject}    The instance associated with the ID or `undefiend`
  */
-export function byId<T extends ParserObject>(id: string, doc: Document = document): T {
-	const idMap = idDocumentMap.get(doc);
-	return idMap && <T> idMap[id];
+export function byId<T extends ParserObject>(id: string): T;
+export function byId<T extends ParserObject>(doc: Document, id: string): T;
+export function byId<T extends ParserObject>(doc: Document | string, id?: string): T {
+	const idMap = isDocument(doc) ? idDocumentMap.get(<Document> doc) : idDocumentMap.get(document);
+	return idMap && <T> idMap[id || <string> doc];
 }
 
 /**

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -6,6 +6,10 @@ import Registry from 'dojo-core/Registry';
 import { queueMicroTask } from 'dojo-core/queue';
 import domWatch, { WatcherRecord, ChangeType } from './watch';
 
+export interface IdMap {
+	[id: string]: ParserObject;
+}
+
 export interface ParserObject {
 	node: HTMLElement;
 	id: string;
@@ -42,7 +46,7 @@ const nodeMap = new WeakMap<HTMLElement, ParserObject>();
 /**
  * A map of document objects to a hash of the object ids and their objects
  */
-const idDocumentMap = new WeakMap<Document, { [id: string]: ParserObject }>();
+const idDocumentMap = new WeakMap<Document, IdMap>();
 
 /**
  * Takes a DOM node and inspects it to see if it should instantiate an object based on its tag name as
@@ -75,14 +79,14 @@ function instantiateParserObject(node: HTMLElement, reject: ParserRejector): Par
 			if (node.id) {
 				let idMap = idDocumentMap.get(node.ownerDocument);
 				if (!idMap) {
-					idDocumentMap.set(node.ownerDocument, (idMap = <{ [id: string]: ParserObject }>{}));
+					idDocumentMap.set(node.ownerDocument, (idMap = <IdMap> {}));
 				}
 				instance.id = node.id;
 				if (!(instance.id in idMap)) {
 					idMap[instance.id] = instance;
 				}
 				else {
-					throw new Error('An instance has already been registered for ID "' + node.id + '".');
+					throw new Error(`An instance has already been registered for ID "${node.id}".`);
 				}
 			}
 			nodeMap.set(node, instance);

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -33,7 +33,11 @@ export var environments = [
 export var maxConcurrency = 2;
 
 // Name of the tunnel class to use for WebDriver tests
-export var tunnel = 'BrowserStackTunnel';
+export var tunnel = 'SauceLabsTunnel';
+export var tunnelOptions = {
+	username: 'mwistrand',
+	accessKey: 'baa1c848-129b-4eb7-81c1-4a5b7037a9cb'
+};
 
 // Configuration options for the module loader; any AMD configuration options supported by the specified AMD loader
 // can be used here

--- a/tests/unit/parser.ts
+++ b/tests/unit/parser.ts
@@ -337,10 +337,10 @@ registerSuite(function () {
 				});
 
 				return parse({ root: doc }).then(function () {
-					assert.instanceOf(byId('myFoo1', doc), Foo, 'Instance retrieved and right type');
-					assert.notStrictEqual(byId('myFoo1', doc), byId('myFoo1'),
+					assert.instanceOf(byId(doc, 'myFoo1'), Foo, 'Instance retrieved and right type');
+					assert.notStrictEqual(byId(doc, 'myFoo1'), byId('myFoo1'),
 						'Instances retrieved from different documents and different objects.');
-					assert.isUndefined(byId('foo', doc), 'Returns undefined when ID not present');
+					assert.isUndefined(byId(doc, 'foo'), 'Returns undefined when ID not present');
 					handle.destroy();
 				});
 			}


### PR DESCRIPTION
Resolves #4. Allows widgets to be registered to multiple documents, without the possibility of ID collisions.