### PR TITLE
Update to allow testing against Sauce Labs and Browserstack

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -111,17 +111,13 @@ module.exports = function (grunt) {
 				runType: 'runner',
 				config: '<%= devDirectory %>/tests/intern'
 			},
-			runner: {
+			browserstack: {},
+			saucelabs: {
 				options: {
-					reporters: [
-						'Combined',
-						{
-							id: 'node_modules/remap-istanbul/lib/intern-reporters/JsonCoverage',
-							filename: 'coverage-runner.json'
-						}
-					]
+					config: '<%= devDirectory %>/tests/intern-saucelabs'
 				}
 			},
+			remote: {},
 			local: {
 				options: {
 					config: '<%= devDirectory %>/tests/intern-local',
@@ -308,6 +304,6 @@ module.exports = function (grunt) {
 	grunt.registerTask('test', [ 'dev', 'intern:client', 'remapIstanbul:client' ]);
 	grunt.registerTask('test-local', [ 'dev', 'intern:local' ]);
 	grunt.registerTask('test-proxy', [ 'dev', 'intern:proxy' ]);
-	grunt.registerTask('ci', [ 'tslint', 'dev', 'intern:client', 'intern:runner', 'coverage', 'clean' ]);
+	grunt.registerTask('ci', [ 'tslint', 'dev', 'intern:client', 'intern:remote', 'coverage', 'clean' ]);
 	grunt.registerTask('default', [ 'clean', 'dev' ]);
 };

--- a/tests/intern-saucelabs.ts
+++ b/tests/intern-saucelabs.ts
@@ -1,0 +1,18 @@
+export * from './intern';
+
+export const environments = [
+	{ browserName: 'internet explorer', version: ['9.0', '10.0', '11.0'], platform: 'Windows 7' },
+	/* Intern 3.0.6 sometimes works on Edge */
+	{ browserName: 'microsoftedge', platform: 'Windows 10' },
+	{ browserName: 'firefox', platform: 'Windows 10' },
+	{ browserName: 'chrome', platform: 'Windows 10' },
+	/* Still appear to be issues on Safari on SauceLabs */
+	/* { browserName: 'safari', version: '9', platform: 'OS X 10.11' },*/
+	{ browserName: 'android', platform: 'Linux', version: '4.4', deviceName: 'Google Nexus 7 HD Emulator' }/*,
+	{ browserName: 'iphone', version: '9.1', deviceName: 'iPhone 6' }*/
+];
+
+/* SauceLabs supports more max concurrency */
+export const maxConcurrency = 4;
+
+export const tunnel = 'SauceLabsTunnel';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
 		"./src/watch.ts",
 		"./tests/functional/all.ts",
 		"./tests/intern-local.ts",
+		"./tests/intern-saucelabs.ts",
 		"./tests/intern.ts",
 		"./tests/support/jsdom.ts",
 		"./tests/typings/chai/chai.d.ts",


### PR DESCRIPTION
Update Gruntfile and intern configs to allow either Saucelabs or BrowserStack to be used based on which grunt task is invoked